### PR TITLE
Add function to check if PDF has warnings

### DIFF
--- a/qpdf-rs/src/lib.rs
+++ b/qpdf-rs/src/lib.rs
@@ -511,4 +511,9 @@ impl QPdf {
         self.foreign.borrow_mut().insert(foreign.as_ref().owner.clone());
         QPdfObject::new(self.clone(), oh)
     }
+
+    /// Return true if PDF has warnings
+    pub fn more_warnings(self: &QPdf) -> bool {
+        unsafe { qpdf_sys::qpdf_more_warnings(self.inner()) != 0 }
+    }
 }


### PR DESCRIPTION
Hi, I use QPDF to fix slightly "broken" PDFs by simply reading and writing them. I needed a way to check if any warnings occurred while reading a PDF so that I know that something is wrong with it and that I need to write it to a new file.